### PR TITLE
handle expiration errors in server response

### DIFF
--- a/scripts/coins-logon-widget.js
+++ b/scripts/coins-logon-widget.js
@@ -177,12 +177,8 @@
 
                 self.form.clearLoading();
 
-                if (accountExpiration - now < 0) {
-                    self.emit(EVENTS.LOGIN_ACCOUNT_EXPIRED, response);
-                } else if (accountExpiration - now < day * 10) {
+                if (accountExpiration - now < day * 10) {
                     self.emit(EVENTS.LOGIN_ACCOUNT_WILL_EXPIRE, response);
-                } else if (passwordExpiration - now < 0) {
-                    self.emit(EVENTS.PASSWORD_EXPIRED, response);
                 } else if (passwordExpiration - now < day * 10) {
                     self.emit(EVENTS.LOGIN_PASSWORD_WILL_EXPIRE, response);
                 } else {
@@ -191,7 +187,13 @@
             })
             .fail(function(error) {
                 self.form.clearLoading();
-                self.emit(EVENTS.LOGIN_ERROR, error);
+                if (error === 'Password expired') {
+                    self.emit(EVENTS.LOGIN_PASSWORD_EXPIRED, error);
+                } else if (error === 'Account expired') {
+                    self.emit(EVENTS.LOGIN_ACCOUNT_EXPIRED, error);
+                } else {
+                    self.emit(EVENTS.LOGIN_ERROR, error);
+                }
             });
     };
 


### PR DESCRIPTION
# Background

The logon widget emits special events when the user's password or account are expired, or are nearly expired. This is done by comparing the user's `acctExpirationDate` and `passwordExpDate` to the `issueDate` of the HAWK credentials returned by a successful login.
# Problem

In the event that the user's account or password have already expired, the server will not return a successful login response. Instead, it will reply with a 401, and a short message (e.g. _Password expired_). Consequently, the current logic for handling account/password expirations is never being executed.
# Solution

Move the expiration event emitting to the `catch` statement.
# Discussion

Testing the server's response message may be brittle. AFAIK, there are no server-side tests to ensure that the response for an expired password will be _Password expired_, so it could change without notice. 

We should put some tests on the server, and in this repo to ensure that this continues to work as expected.
