### PR TITLE
remove auth cookie on logout

### DIFF
--- a/scripts/lib/auth.js
+++ b/scripts/lib/auth.js
@@ -59,13 +59,14 @@
      *
      * @param  {string} url
      * @param  {string} method
+     * @param  {object} credentials
      * @return {object}
      */
     function getHawkHeaders(url, method, credentials) {
         var header = hawk.client.header(
             url,
             method,
-            { credentials:  getAuthCredentials() }
+            { credentials:  credentials }
         );
 
         return {
@@ -198,9 +199,9 @@
 
         jQuery.ajax({
             dataType: 'json',
-            headers: getHawkHeaders(url, method),
+            headers: getHawkHeaders(url, method, credentials),
             type: method,
-            url: getApiUrl('/auth/keys/' + id),
+            url: url,
             xhrFields: {
                 withCredentials: true
             },

--- a/scripts/lib/auth.js
+++ b/scripts/lib/auth.js
@@ -85,6 +85,28 @@
     }
 
     /**
+     * Remove the CAS_Auth_User cookie
+     *
+     * @return {null}
+     */
+    function removeAuthCookie() {
+        var cookieValue = 'REMOVED';
+        var domain = '.mrn.org';
+        var path = '/';
+        var name = 'CAS_Auth_User';
+        document.cookie = [
+            name,
+            '=',
+            cookieValue,
+            '; Path=',
+            path,
+            '; Domain=',
+            domain,
+            ';'
+        ].join('');
+    }
+
+    /**
      * Get options.
      *
      * @return {object}
@@ -123,7 +145,7 @@
     function mapApiError(error) {
         var statusText = error.statusText;
         var message;
-        if (error.responseText) { 
+        if (error.responseText) {
             message = (JSON.parse(error.responseText) || {});
             message = (message.error || {}).message || '';
         }
@@ -170,9 +192,9 @@
      */
     function logout() {
         var deferred = jQuery.Deferred();
-        var id = getAuthCredentials().id;
+        var credentials = getAuthCredentials();
         var method = 'DELETE';
-        var url = getApiUrl('/auth/keys/' + id);
+        var url = getApiUrl('/auth/keys/' + credentials.id);
 
         jQuery.ajax({
             dataType: 'json',
@@ -190,6 +212,7 @@
                 deferred.reject(mapApiError(error));
             })
             .always(function() {
+                removeAuthCookie();
                 return setAuthCredentials({
                     date: Date.now(),
                     status: 'logged out',


### PR DESCRIPTION
Regardless of success or failure, we should remove the auth cookie when `coinsLogonWidget.logout` is called. 
# Discussion

For now, the cookie name and domain name are hard-coded. I think that is alright, but we may eventually want to move them to `options`.
