### PR TITLE
Add unmet peer dependecy ajv and specify loader syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "homepage": "https://github.com/MRN-Code/coins-logon-widget#readme",
   "devDependencies": {
+    "ajv": "^6.0.0",
     "autoprefixer": "^6.0.3",
     "bluebird": "^3.0.5",
     "finalhandler": "^0.4.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 var test = require('tape');
 var CoinsLogonWidget = require('../scripts/coins-logon-widget.js');
 var cookies = require('js-cookie');
-var html = require('html!./index.html');
+var html = require('html-loader!./index.html');
 var jQuery = require('jquery');
 var messages = require('../scripts/lib/messages.js');
 var Promise = this.Promise = require('bluebird'); // phantomJS polyfill. seriously. :-|


### PR DESCRIPTION
#### Asana
https://app.asana.com/0/52243410440449/656084807774369

# Problem
After the updates from #12, this package was missing peer dependency `ajv` and the `publish` command wouldn't run.

# Solution
Add dependency to `package.json`.
Also, update `html-loader` syntax.